### PR TITLE
Add Breadcrumbs

### DIFF
--- a/app/components/daisy_ui/item.rb
+++ b/app/components/daisy_ui/item.rb
@@ -2,8 +2,9 @@
 
 module DaisyUI
   class Item < BaseComponent
-    def initialize(href: nil, **system_arguments)
+    def initialize(href: nil, icon_span: false, **system_arguments)
       @href = href
+      @icon_span = icon_span
       super(**system_arguments)
     end
 
@@ -14,13 +15,11 @@ module DaisyUI
         elsif @href == ''
           # Render as link without href attribute (for breadcrumbs compatibility)
           tag.a(class: system_arguments[:class]) { content }
+        elsif @icon_span
+          # Apply special styling for items with icons (when no href)
+          tag.span(class: 'inline-flex items-center gap-2') { content }
         else
-          # Check if content contains icons to apply special styling for breadcrumbs
-          if content.to_s.include?('<i class=')
-            tag.span(class: 'inline-flex items-center gap-2') { content }
-          else
-            content
-          end
+          content
         end
       end
     end

--- a/app/components/daisy_ui/item.rb
+++ b/app/components/daisy_ui/item.rb
@@ -10,9 +10,9 @@ module DaisyUI
 
     def call
       tag.li do
-        if @href && @href != ''
+        if @href&.not_blank?
           tag.a(href: @href, class: system_arguments[:class]) { content }
-        elsif @href == ''
+        elsif @href.blank?
           # Render as link without href attribute (for breadcrumbs compatibility)
           tag.a(class: system_arguments[:class]) { content }
         elsif @icon_span

--- a/app/components/daisy_ui/item.rb
+++ b/app/components/daisy_ui/item.rb
@@ -9,10 +9,18 @@ module DaisyUI
 
     def call
       tag.li do
-        if @href
+        if @href && @href != ''
           tag.a(href: @href, class: system_arguments[:class]) { content }
+        elsif @href == ''
+          # Render as link without href attribute (for breadcrumbs compatibility)
+          tag.a(class: system_arguments[:class]) { content }
         else
-          content
+          # Check if content contains icons to apply special styling for breadcrumbs
+          if content.to_s.include?('<i class=')
+            tag.span(class: 'inline-flex items-center gap-2') { content }
+          else
+            content
+          end
         end
       end
     end

--- a/app/components/daisy_ui/item.rb
+++ b/app/components/daisy_ui/item.rb
@@ -10,18 +10,32 @@ module DaisyUI
 
     def call
       tag.li do
-        if @href&.not_blank?
-          tag.a(href: @href, class: system_arguments[:class]) { content }
-        elsif @href.blank?
-          # Render as link without href attribute (for breadcrumbs compatibility)
-          tag.a(class: system_arguments[:class]) { content }
-        elsif @icon_span
-          # Apply special styling for items with icons (when no href)
-          tag.span(class: 'inline-flex items-center gap-2') { content }
-        else
-          content
-        end
+        render_item_content
       end
+    end
+
+    private
+
+    def render_item_content
+      if @href.present? && @href != ''
+        tag.a(href: @href, class: system_arguments[:class]) { content }
+      elsif @href == ''
+        render_empty_href_link
+      elsif @icon_span
+        render_icon_span
+      else
+        content
+      end
+    end
+
+    def render_empty_href_link
+      # Render as link without href attribute (for breadcrumbs compatibility)
+      tag.a(class: system_arguments[:class]) { content }
+    end
+
+    def render_icon_span
+      # Apply special styling for items with icons (when no href)
+      tag.span(class: 'inline-flex items-center gap-2') { content }
     end
   end
 end

--- a/app/components/daisy_ui/item.rb
+++ b/app/components/daisy_ui/item.rb
@@ -17,7 +17,7 @@ module DaisyUI
     private
 
     def render_item_content
-      if @href.present? && @href != ''
+      if @href.present?
         tag.a(href: @href, class: system_arguments[:class]) { content }
       elsif @href == ''
         render_empty_href_link

--- a/app/components/daisy_ui/navigation/breadcrumbs.rb
+++ b/app/components/daisy_ui/navigation/breadcrumbs.rb
@@ -115,7 +115,7 @@ module DaisyUI
 
     def join_text_and_icon(text, icon)
       if icon
-        safe_join([icon, ' ', text, ' '].compact)
+        safe_join([icon, ' ', text].compact)
       else
         text
       end

--- a/app/components/daisy_ui/navigation/breadcrumbs.rb
+++ b/app/components/daisy_ui/navigation/breadcrumbs.rb
@@ -78,16 +78,15 @@ module DaisyUI
       super(**system_arguments)
 
       items&.each do |item_options|
-        # Transform 'text' parameter to block content for DaisyUI::Item
+        # Transform 'text' and 'icon' parameters to block content for DaisyUI::Item
         text = item_options.delete(:text)
         icon = item_options.delete(:icon)
-        
+
+        # Add icon_span parameter if there's an icon and no href
+        item_options[:icon_span] = true if icon && !item_options[:href]
+
         with_item(**item_options) do
-          if icon
-            safe_join([icon, ' ', text, ' '].compact)
-          else
-            text
-          end
+          join_text_and_icon(text, icon)
         end
       end
 
@@ -112,6 +111,14 @@ module DaisyUI
       modifiers << @size if @size.present?
 
       class_names(modifiers, system_arguments[:class])
+    end
+
+    def join_text_and_icon(text, icon)
+      if icon
+        safe_join([icon, ' ', text, ' '].compact)
+      else
+        text
+      end
     end
   end
 end

--- a/app/components/daisy_ui/navigation/breadcrumbs.rb
+++ b/app/components/daisy_ui/navigation/breadcrumbs.rb
@@ -82,8 +82,8 @@ module DaisyUI
         text = item_options.delete(:text)
         icon = item_options.delete(:icon)
 
-        # Add icon_span parameter if there's an icon and no href
-        item_options[:icon_span] = true if icon && !item_options[:href]
+        # Add icon_span parameter if there's an icon and no href (nil or empty)
+        item_options[:icon_span] = true if icon && item_options[:href].nil?
 
         with_item(**item_options) do
           join_text_and_icon(text, icon)
@@ -115,7 +115,7 @@ module DaisyUI
 
     def join_text_and_icon(text, icon)
       if icon
-        safe_join([icon, ' ', text].compact)
+        safe_join([icon, text].compact)
       else
         text
       end

--- a/app/components/daisy_ui/navigation/breadcrumbs.rb
+++ b/app/components/daisy_ui/navigation/breadcrumbs.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module DaisyUI
+  # Breadcrumbs component implementing DaisyUI's breadcrumbs styles
+  #
+  # @example Basic usage with parameters
+  #   <%= render DaisyUI::Breadcrumbs.new(
+  #     items: [
+  #       { text: "Home", href: "/" },
+  #       { text: "Documents", href: "/documents" },
+  #       { text: "Add Document" }
+  #     ]
+  #   ) %>
+  #
+  # @example With icons using parameters
+  #   <%= render DaisyUI::Breadcrumbs.new(
+  #     items: [
+  #       { text: "Home", href: "/", icon: phosphor_icon('ph-house') },
+  #       { text: "Documents", href: "/documents", icon: phosphor_icon('ph-folder') },
+  #       { text: "Add Document", icon: phosphor_icon('ph-plus') }
+  #     ]
+  #   ) %>
+  #
+  # @example With size and custom styling
+  #   <%= render DaisyUI::Breadcrumbs.new(
+  #     size: :lg,
+  #     class: "max-w-xs",
+  #     items: [
+  #       { text: "Long text 1" },
+  #       { text: "Long text 2" },
+  #       { text: "Long text 3" }
+  #     ]
+  #   ) %>
+  #
+  # @example Using slots for complex items
+  #   <%= render(DaisyUI::Breadcrumbs.new) do |breadcrumbs| %>
+  #     <% breadcrumbs.with_item(href: "/") { "Home" } %>
+  #     <% breadcrumbs.with_item(href: "/documents") { "Documents" } %>
+  #     <% breadcrumbs.with_item { "Add Document" } %>
+  #   <% end %>
+  #
+  # @example Hybrid approach (parameters + slots)
+  #   <%= render DaisyUI::Breadcrumbs.new(
+  #     size: :sm,
+  #     items: [
+  #       { text: "Home", href: "/" },
+  #       { text: "Documents", href: "/documents" }
+  #     ]
+  #   ) do |breadcrumbs| %>
+  #     <% breadcrumbs.with_item { "Add Document" } %>
+  #   <% end %>
+  #
+  # @note If both `items` parameters and a block with `with_item` are provided,
+  #   the items from parameters will be rendered first, followed by items defined in the block.
+
+  class Breadcrumbs < BaseComponent
+    # Available breadcrumb sizes from DaisyUI/Tailwind
+    SIZES = {
+      xs: 'text-xs',
+      sm: 'text-sm',
+      md: 'text-base',
+      lg: 'text-lg',
+      xl: 'text-xl'
+    }.freeze
+
+    # Polymorphic slot for breadcrumb items using the existing DaisyUI::Item component
+    renders_many :items, 'DaisyUI::Item'
+
+    # @param items [Array<Hash>] Optional array of item hashes. Each hash is passed as keyword arguments to
+    #   `DaisyUI::Item.new`. If provided, item elements are added to the breadcrumbs.
+    # @param size [Symbol] Breadcrumb text size (:xs, :sm, :md, :lg, :xl)
+    # @param system_arguments [Hash] Additional HTML attributes for the breadcrumbs container.
+    def initialize(
+      items: nil,
+      size: :sm,
+      **system_arguments
+    )
+      super(**system_arguments)
+
+      items&.each do |item_options|
+        # Transform 'text' parameter to block content for DaisyUI::Item
+        text = item_options.delete(:text)
+        icon = item_options.delete(:icon)
+        
+        with_item(**item_options) do
+          if icon
+            safe_join([icon, ' ', text, ' '].compact)
+          else
+            text
+          end
+        end
+      end
+
+      @size = build_argument(size, SIZES, 'size')
+    end
+
+    def call
+      tag.div(class: computed_classes, **system_arguments.except(:class)) do
+        tag.ul do
+          safe_join([
+                      content,
+                      items
+                    ])
+        end
+      end
+    end
+
+    private
+
+    def computed_classes
+      modifiers = ['breadcrumbs']
+      modifiers << @size if @size.present?
+
+      class_names(modifiers, system_arguments[:class])
+    end
+  end
+end

--- a/app/helpers/daisy_ui/icons_helper.rb
+++ b/app/helpers/daisy_ui/icons_helper.rb
@@ -33,7 +33,12 @@ module DaisyUI
       discord: 'ph-discord-logo',
       twitch: 'ph-twitch-logo',
       slack: 'ph-slack-logo',
-      wechat: 'ph-wechat-logo'
+      wechat: 'ph-wechat-logo',
+      chart_bar: 'ph-chart-bar',
+      plus: 'ph-plus',
+      shopping_cart: 'ph-shopping-cart',
+      bell: 'ph-bell',
+      magnifying_glass: 'ph-magnifying-glass'
     }.freeze
 
     def phosphor_icon(icon_class, options = {})

--- a/test/components/daisy_ui/navigation/breadcrumbs_test.rb
+++ b/test/components/daisy_ui/navigation/breadcrumbs_test.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module DaisyUI
+  module Navigation
+    class BreadcrumbsTest < DaisyUI::ComponentTestCase
+      include PreviewTestConcern
+
+      test_all_preview_examples(
+        preview_class: BreadcrumbsPreview,
+        component_name: 'breadcrumbs',
+        exclude: %w[playground]
+      )
+
+      def test_playground
+        render_preview(:playground, from: BreadcrumbsPreview)
+        assert_selector 'div.breadcrumbs'
+      end
+
+      def test_basic_breadcrumbs
+        render_inline(DaisyUI::Breadcrumbs.new(
+                        items: [
+                          { text: 'Home', href: '/' },
+                          { text: 'Current' }
+                        ]
+                      ))
+
+        assert_selector 'div.breadcrumbs'
+        assert_selector 'ul'
+        assert_selector 'li', count: 2
+        assert_selector 'a[href="/"]', text: 'Home'
+        assert_selector 'li', text: 'Current'
+      end
+
+      def test_with_custom_size
+        render_inline(DaisyUI::Breadcrumbs.new(
+                        size: :lg,
+                        items: [{ text: 'Test' }]
+                      ))
+
+        assert_selector 'div.breadcrumbs.text-lg'
+      end
+
+      def test_with_custom_classes
+        render_inline(DaisyUI::Breadcrumbs.new(
+                        class: 'max-w-xs custom-class',
+                        items: [{ text: 'Test' }]
+                      ))
+
+        assert_selector 'div.breadcrumbs.max-w-xs.custom-class'
+      end
+
+      def test_slot_based_items
+        render_inline(DaisyUI::Breadcrumbs.new) do |breadcrumbs|
+          breadcrumbs.with_item(href: '/') { 'Home' }
+          breadcrumbs.with_item { 'Current' }
+        end
+
+        assert_selector 'div.breadcrumbs'
+        assert_selector 'a[href="/"]', text: 'Home'
+        assert_selector 'li', text: 'Current'
+      end
+
+      def test_hybrid_approach
+        render_inline(DaisyUI::Breadcrumbs.new(
+                        items: [{ text: 'Home', href: '/' }]
+                      )) do |breadcrumbs|
+          breadcrumbs.with_item { 'Current' }
+        end
+
+        assert_selector 'div.breadcrumbs'
+        assert_selector 'li', count: 2
+        assert_selector 'a[href="/"]', text: 'Home'
+        assert_selector 'li', text: 'Current'
+      end
+    end
+  end
+end

--- a/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
+++ b/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
@@ -50,7 +50,7 @@ module DaisyUI
         render DaisyUI::Breadcrumbs.new(
           items: [
             { text: 'Home', href: '', icon: tag.i(class: 'ph ph-house h-4 w-4') },
-            { text: 'Documents', href: '', icon: tag.i(class: 'ph ph-house h-4 w-4') },
+            { text: 'Documents', href: '', icon: tag.i(class: 'ph ph-folder h-4 w-4') },
             { text: 'Add Document', icon: tag.i(class: 'ph ph-plus h-4 w-4') }
           ]
         )

--- a/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
+++ b/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+# @label Breadcrumbs
+module DaisyUI
+  module Navigation
+    class BreadcrumbsPreview < ViewComponent::Preview
+      include DaisyUI::IconsHelper
+
+      # @!group Playground
+
+      # Playground
+      # ---
+      # Interactive playground for Breadcrumbs component
+      # @param size select { choices: [xs, sm, md, lg, xl] }
+      # @param custom_classes text "Custom CSS classes (e.g., 'max-w-xs')"
+      def playground(
+        size: :sm,
+        custom_classes: ''
+      )
+        render DaisyUI::Breadcrumbs.new(
+          size: size,
+          class: custom_classes,
+          items: [
+            { text: safe_join([phosphor_icon('ph-house', class: 'h-4 w-4'), ' Home']), href: '#' },
+            { text: safe_join([phosphor_icon('ph-folder', class: 'h-4 w-4'), ' Documents']), href: '#' },
+            { text: safe_join([phosphor_icon('ph-plus', class: 'h-4 w-4'), ' Add Document']) }
+          ]
+        )
+      end
+
+      # @!endgroup
+
+      # Breadcrumbs
+      # ---------------
+      # Basic breadcrumbs with text links
+      def breadcrumbs
+        render DaisyUI::Breadcrumbs.new(
+          items: [
+            { text: 'Home', href: '' },
+            { text: 'Documents', href: '' },
+            { text: 'Add Document' }
+          ]
+        )
+      end
+
+      # Breadcrumbs with icons
+      # ---------------
+      # Breadcrumbs with icons for each item
+      def breadcrumbs_with_icons
+        render DaisyUI::Breadcrumbs.new(
+          items: [
+            { text: 'Home', href: '', icon: tag.i(class: 'ph ph-house h-4 w-4') },
+            { text: 'Documents', href: '', icon: tag.i(class: 'ph ph-house h-4 w-4') },
+            { text: 'Add Document', icon: tag.i(class: 'ph ph-plus h-4 w-4') }
+          ]
+        )
+      end
+
+      # Breadcrumbs with max width
+      # ---------------
+      # Breadcrumbs with max width constraint
+      def breadcrumbs_with_max_width
+        render DaisyUI::Breadcrumbs.new(
+          class: 'max-w-xs',
+          items: [
+            { text: 'Long text 1' },
+            { text: 'Long text 2' },
+            { text: 'Long text 3' },
+            { text: 'Long text 4' },
+            { text: 'Long text 5' }
+          ]
+        )
+      end
+    end
+  end
+end

--- a/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
+++ b/test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb
@@ -21,9 +21,9 @@ module DaisyUI
           size: size,
           class: custom_classes,
           items: [
-            { text: safe_join([phosphor_icon('ph-house', class: 'h-4 w-4'), ' Home']), href: '#' },
-            { text: safe_join([phosphor_icon('ph-folder', class: 'h-4 w-4'), ' Documents']), href: '#' },
-            { text: safe_join([phosphor_icon('ph-plus', class: 'h-4 w-4'), ' Add Document']) }
+            { text: 'Home', href: '#', icon: phosphor_icon('ph-house', class: 'h-4 w-4') },
+            { text: 'Documents', href: '#', icon: phosphor_icon('ph-folder', class: 'h-4 w-4') },
+            { text: 'Add Document', icon: phosphor_icon('ph-plus', class: 'h-4 w-4') }
           ]
         )
       end

--- a/test/fixtures/components/breadcrumbs/breadcrumbs.html
+++ b/test/fixtures/components/breadcrumbs/breadcrumbs.html
@@ -1,0 +1,7 @@
+<div class="breadcrumbs text-sm">
+  <ul>
+    <li><a>Home</a></li>
+    <li><a>Documents</a></li>
+    <li>Add Document</li>
+  </ul>
+</div>

--- a/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
+++ b/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
@@ -1,0 +1,22 @@
+<div class="breadcrumbs text-sm">
+  <ul>
+    <li>
+      <a>
+        <i class="ph ph-house h-4 w-4"></i>
+        Home
+      </a>
+    </li>
+    <li>
+      <a>
+        <i class="ph ph-house h-4 w-4"></i>
+        Documents
+      </a>
+    </li>
+    <li>
+      <span class="inline-flex items-center gap-2">
+        <i class="ph ph-plus h-4 w-4"></i>
+        Add Document
+      </span>
+    </li>
+  </ul>
+</div>

--- a/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
+++ b/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
@@ -8,7 +8,7 @@
     </li>
     <li>
       <a>
-        <i class="ph ph-house h-4 w-4"></i>
+        <i class="ph ph-folder h-4 w-4"></i>
         Documents
       </a>
     </li>

--- a/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
+++ b/test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html
@@ -1,22 +1,15 @@
 <div class="breadcrumbs text-sm">
   <ul>
     <li>
-      <a>
-        <i class="ph ph-house h-4 w-4"></i>
-        Home
-      </a>
+      <a><i class="ph ph-house h-4 w-4"></i>Home</a>
     </li>
     <li>
       <a>
-        <i class="ph ph-folder h-4 w-4"></i>
-        Documents
-      </a>
+        <i class="ph ph-folder h-4 w-4"></i>Documents</a>
     </li>
     <li>
       <span class="inline-flex items-center gap-2">
-        <i class="ph ph-plus h-4 w-4"></i>
-        Add Document
-      </span>
+        <i class="ph ph-plus h-4 w-4"></i>Add Document</span>
     </li>
   </ul>
 </div>

--- a/test/fixtures/components/breadcrumbs/breadcrumbs_with_max_width.html
+++ b/test/fixtures/components/breadcrumbs/breadcrumbs_with_max_width.html
@@ -1,0 +1,9 @@
+<div class="breadcrumbs max-w-xs text-sm">
+  <ul>
+    <li>Long text 1</li>
+    <li>Long text 2</li>
+    <li>Long text 3</li>
+    <li>Long text 4</li>
+    <li>Long text 5</li>
+  </ul>
+</div>


### PR DESCRIPTION
This pull request introduces a new `Breadcrumbs` component in the `DaisyUI` module, along with enhancements to the `Item` component to support icon-based styling and link-less items. It also adds several new icons to the `IconsHelper` module and includes comprehensive tests and previews for the `Breadcrumbs` component.

### New `Breadcrumbs` Component:
* [`app/components/daisy_ui/navigation/breadcrumbs.rb`](diffhunk://#diff-a06990d7edeb966f9cfe70c067c406c2b63d329a195aae1552a9da791016cc35R1-R124): Implements the `Breadcrumbs` component with support for text links, icons, size customization, and hybrid approaches combining parameters and slots.

### Enhancements to `Item` Component:
* [`app/components/daisy_ui/item.rb`](diffhunk://#diff-29f7852737a875c51b37cb8365db3675e1db6632feae474d3ec0300a2a00b292L5-R20): Adds support for `icon_span` styling and link-less items, enabling compatibility with breadcrumbs and special styling for items with icons.

### New Icons:
* [`app/helpers/daisy_ui/icons_helper.rb`](diffhunk://#diff-c9b9abf7b5e2f5d7bbfae6ce41cb774869a13e214458f33560744d602264c41cL36-R41): Adds new icons (`chart_bar`, `plus`, `shopping_cart`, `bell`, `magnifying_glass`) to the `IconsHelper` module for use in components like `Breadcrumbs`.

### Tests for `Breadcrumbs` Component:
* [`test/components/daisy_ui/navigation/breadcrumbs_test.rb`](diffhunk://#diff-e9ca050a8138b4c081a1ef2f776bb390059dfac45cc556782498a4cf5b318880R1-R79): Includes tests for various `Breadcrumbs` configurations, including basic usage, custom sizes, custom classes, slot-based items, and hybrid approaches.

### Previews and Fixtures:
* [`test/components/previews/daisy_ui/navigation/breadcrumbs_preview.rb`](diffhunk://#diff-d7284d5a53c75e6203bc691323715191c2faa0a53098a6ee4a1a11f498de19ffR1-R76): Adds interactive previews for the `Breadcrumbs` component, showcasing different configurations such as icons, max width, and playground mode.
* [`test/fixtures/components/breadcrumbs/breadcrumbs.html`](diffhunk://#diff-4d546a533132507911923f16856e7fc481cbb7c0eb17f002eb204579c4270bdeR1-R7): Provides HTML fixture for basic breadcrumbs.
* [`test/fixtures/components/breadcrumbs/breadcrumbs_with_icons.html`](diffhunk://#diff-5f62ddc10f4368c2ae2910f95a19361405133c0650a688eba639da31dfc1d0f5R1-R22): Provides HTML fixture for breadcrumbs with icons.
* [`test/fixtures/components/breadcrumbs/breadcrumbs_with_max_width.html`](diffhunk://#diff-9dd7917ccc5cc181bbba3326d24e1cfe77868f8c681fde4c9f60199bd31a04d8R1-R9): Provides HTML fixture for breadcrumbs with max width constraint.